### PR TITLE
자유/멘토/공지 게시판, 자유/멘토 게시판 댓글, 게시글 타입, 댓글/후기 타입, 유저, 신청 대기열 엔티티 생성 및 컬럼 추가

### DIFF
--- a/src/main/java/com/hugudungs/hugupjigup/data/entity/apply/ApplyList.java
+++ b/src/main/java/com/hugudungs/hugupjigup/data/entity/apply/ApplyList.java
@@ -1,0 +1,44 @@
+package com.hugudungs.hugupjigup.data.entity.apply;
+
+import com.hugudungs.hugupjigup.data.entity.board.MatchingText;
+import com.hugudungs.hugupjigup.data.entity.common.BaseEntity;
+import com.hugudungs.hugupjigup.data.entity.user.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.util.Date;
+
+@Entity
+@Table(name = "apply_list")
+@Getter
+@Setter
+@NoArgsConstructor
+@AttributeOverrides({
+        @AttributeOverride(name = "id", column = @Column(name = "apply_list_id", nullable = false))
+})
+public class ApplyList extends BaseEntity {
+
+    @ManyToOne
+    @JoinColumn(name = "matching_text_id", nullable = false)
+    private MatchingText matchingText;  // FK - MatchingText 테이블 참조
+
+    @OneToOne
+    @JoinColumn(name = "userId", nullable = false)
+    private User user;  // FK - Users 테이블 참조
+
+    @Column(name = "apply_date", nullable = false)
+    @Temporal(TemporalType.DATE)
+    private Date applyDate;  // 신청 날짜
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private ApplyStatus status;  // 신청 상태 (ENUM)
+
+    @Column(name = "content", columnDefinition = "TEXT")
+    private String content;  // 신청 내용 (NULL 허용)
+
+    public enum ApplyStatus {
+        PENDING, APPROVED, REJECTED
+    }
+}

--- a/src/main/java/com/hugudungs/hugupjigup/data/entity/board/FreeText.java
+++ b/src/main/java/com/hugudungs/hugupjigup/data/entity/board/FreeText.java
@@ -1,0 +1,35 @@
+package com.hugudungs.hugupjigup.data.entity.board;
+
+import com.hugudungs.hugupjigup.data.entity.user.User;
+import com.hugudungs.hugupjigup.data.entity.text_comment_type.TextType;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.util.Date;
+
+@Entity
+@Table(name = "free_text")
+@Getter
+@Setter
+@NoArgsConstructor
+@AttributeOverrides({
+        @AttributeOverride(name = "id", column = @Column(name = "free_text_id", nullable = false)),
+        @AttributeOverride(name = "title", column = @Column(name = "free_title", nullable = false)),
+        @AttributeOverride(name = "content", column = @Column(name = "free_content", nullable = false, columnDefinition = "TEXT")),
+        @AttributeOverride(name = "views", column = @Column(name = "free_number", columnDefinition = "INT DEFAULT 0"))
+})
+public class FreeText extends BaseBoardEntity {
+
+    @OneToOne
+    @JoinColumn(name = "userId", nullable = false)
+    private User user;  // FK - Users 테이블 참조
+
+    @OneToOne
+    @JoinColumn(name = "text_type_id", nullable = false)
+    private TextType textType;  // FK - TextType 테이블 참조
+
+    @Column(name = "free_date", nullable = false)
+    @Temporal(TemporalType.DATE)
+    private Date date;  // 작성 날짜
+}

--- a/src/main/java/com/hugudungs/hugupjigup/data/entity/board/MatchingText.java
+++ b/src/main/java/com/hugudungs/hugupjigup/data/entity/board/MatchingText.java
@@ -1,0 +1,38 @@
+package com.hugudungs.hugupjigup.data.entity.board;
+
+import com.hugudungs.hugupjigup.data.entity.text_comment_type.TextType;
+import com.hugudungs.hugupjigup.data.entity.user.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.util.Date;
+
+@Entity
+@Table(name = "matching_text")
+@Getter
+@Setter
+@NoArgsConstructor
+@AttributeOverrides({
+        @AttributeOverride(name = "id", column = @Column(name = "matching_text_id")),
+        @AttributeOverride(name = "title", column = @Column(name = "matching_title", nullable = false)),
+        @AttributeOverride(name = "content", column = @Column(name = "matching_text", nullable = false, columnDefinition = "TEXT")),
+        @AttributeOverride(name = "views", column = @Column(name = "matching_number", columnDefinition = "INT DEFAULT 0"))
+})
+public class MatchingText extends BaseBoardEntity {
+
+    @OneToOne
+    @JoinColumn(name = "userId", nullable = false)
+    private User user;  // FK - Users 테이블 참조
+
+    @OneToOne
+    @JoinColumn(name = "text_type_id", nullable = false)
+    private TextType textType;  // FK - TextType 테이블 참조
+
+    @Column(name = "matching_date", nullable = false)
+    @Temporal(TemporalType.DATE)
+    private Date date;  // 작성 날짜
+
+    @Column(name = "tag", nullable = false)
+    private String tag;  // 태그 (직업, 기술)
+}

--- a/src/main/java/com/hugudungs/hugupjigup/data/entity/board/Notice.java
+++ b/src/main/java/com/hugudungs/hugupjigup/data/entity/board/Notice.java
@@ -20,11 +20,11 @@ import java.util.Date;
         @AttributeOverride(name = "views", column = @Column(name = "notice_number", columnDefinition = "INT DEFAULT 0"))
 })
 public class Notice extends BaseBoardEntity {
-    @ManyToOne
+    @OneToOne
     @JoinColumn(name = "notice_text_userId", nullable = false)
     private User user;  // FK - Users 테이블 참조
 
-    @ManyToOne
+    @OneToOne
     @JoinColumn(name = "text_type_id", nullable = false)
     private TextType textType;  // FK - TextType 테이블 참조
 

--- a/src/main/java/com/hugudungs/hugupjigup/data/entity/board/Notice.java
+++ b/src/main/java/com/hugudungs/hugupjigup/data/entity/board/Notice.java
@@ -1,15 +1,34 @@
 package com.hugudungs.hugupjigup.data.entity.board;
 
-import jakarta.persistence.AttributeOverride;
-import jakarta.persistence.AttributeOverrides;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
+import com.hugudungs.hugupjigup.data.entity.text_comment_type.TextType;
+import com.hugudungs.hugupjigup.data.entity.user.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.util.Date;
 
 @Entity
 @Table(name = "notice")
+@Getter
+@Setter
+@NoArgsConstructor
 @AttributeOverrides({
-        @AttributeOverride(name = "title", column = @Column(name = "notice_title")),
-        @AttributeOverride(name = "content", column = @Column(name = "notice_content"))
+        @AttributeOverride(name = "id", column = @Column(name = "notice_text_id", nullable = false)),
+        @AttributeOverride(name = "title", column = @Column(name = "notice_title", nullable = false)),
+        @AttributeOverride(name = "content", column = @Column(name = "notice_content", nullable = false, columnDefinition = "TEXT")),
+        @AttributeOverride(name = "views", column = @Column(name = "notice_number", columnDefinition = "INT DEFAULT 0"))
 })
-public class Notice extends BaseBoardEntity { }
+public class Notice extends BaseBoardEntity {
+    @ManyToOne
+    @JoinColumn(name = "notice_text_userId", nullable = false)
+    private User user;  // FK - Users 테이블 참조
+
+    @ManyToOne
+    @JoinColumn(name = "text_type_id", nullable = false)
+    private TextType textType;  // FK - TextType 테이블 참조
+
+    @Column(name = "notice_date", nullable = false)
+    @Temporal(TemporalType.DATE)
+    private Date date;  // 작성 날짜
+}

--- a/src/main/java/com/hugudungs/hugupjigup/data/entity/comment/FreeComment.java
+++ b/src/main/java/com/hugudungs/hugupjigup/data/entity/comment/FreeComment.java
@@ -1,0 +1,41 @@
+package com.hugudungs.hugupjigup.data.entity.comment;
+
+import com.hugudungs.hugupjigup.data.entity.board.FreeText;
+import com.hugudungs.hugupjigup.data.entity.common.BaseEntity;
+import com.hugudungs.hugupjigup.data.entity.user.User;
+import com.hugudungs.hugupjigup.data.entity.text_comment_type.CommentType;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.util.Date;
+
+@Entity
+@Table(name = "free_comment")
+@Getter
+@Setter
+@NoArgsConstructor
+@AttributeOverrides({
+        @AttributeOverride(name = "id", column = @Column(name = "free_text_comment_id", nullable = false))
+})
+public class FreeComment extends BaseEntity {
+
+    @OneToOne
+    @JoinColumn(name = "comment_type_id", nullable = false)
+    private CommentType commentType;  // FK - 댓글 유형 참조
+
+    @ManyToOne
+    @JoinColumn(name = "free_text_id", nullable = false)
+    private FreeText freeText;  // FK - 자유 게시판 글 참조
+
+    @ManyToOne
+    @JoinColumn(name = "free_comment_userId", nullable = false)
+    private User user;  // FK - Users 테이블 참조 (작성자)
+
+    @Column(name = "free_comment_text", nullable = false, columnDefinition = "TEXT")
+    private String content;  // 댓글 내용
+
+    @Column(name = "free_comment_date", nullable = false)
+    @Temporal(TemporalType.DATE)
+    private Date date;  // 댓글 작성 날짜
+}

--- a/src/main/java/com/hugudungs/hugupjigup/data/entity/comment/MatchingComment.java
+++ b/src/main/java/com/hugudungs/hugupjigup/data/entity/comment/MatchingComment.java
@@ -1,0 +1,49 @@
+package com.hugudungs.hugupjigup.data.entity.comment;
+
+import com.hugudungs.hugupjigup.data.entity.common.BaseEntity;
+import com.hugudungs.hugupjigup.data.entity.board.MatchingText;
+import com.hugudungs.hugupjigup.data.entity.text_comment_type.CommentType;
+import com.hugudungs.hugupjigup.data.entity.apply.ApplyList;
+import com.hugudungs.hugupjigup.data.entity.user.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.util.Date;
+
+@Entity
+@Table(name = "matching_comment")
+@Getter
+@Setter
+@NoArgsConstructor
+@AttributeOverrides({
+        @AttributeOverride(name = "id", column = @Column(name = "matching_text_comment_id", nullable = false))
+})
+public class MatchingComment extends BaseEntity {
+
+    @OneToOne
+    @JoinColumn(name = "comment_type_id", nullable = false)
+    private CommentType commentType;  // FK - 댓글 유형 참조
+
+    @ManyToOne
+    @JoinColumn(name = "matching_text_id", nullable = false)
+    private MatchingText matchingText;  // FK - MatchingText 테이블 참조
+
+    @ManyToOne
+    @JoinColumn(name = "matching_comment_userId", nullable = false)
+    private User user;  // FK - Users 테이블 참조 (작성자)
+
+    @OneToOne
+    @JoinColumn(name = "apply_list_id", nullable = false)
+    private ApplyList applyList;  // FK - ApplyList 테이블 참조
+
+    @Column(name = "matching_comment_text", nullable = false, columnDefinition = "TEXT")
+    private String content;  // 후기 내용
+
+    @Column(name = "matching_comment_date", nullable = false)
+    @Temporal(TemporalType.DATE)
+    private Date date;  // 후기 작성 날짜
+
+    @Column(name = "rate", nullable = false)
+    private float rate;  // 평점
+}

--- a/src/main/java/com/hugudungs/hugupjigup/data/entity/common/BaseEntity.java
+++ b/src/main/java/com/hugudungs/hugupjigup/data/entity/common/BaseEntity.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 @MappedSuperclass
 public abstract class BaseEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // AUTO에서 IDENTITY로 변경 (AUTO_INCREMENT)
     private long id;
 
     @Column(name = "created_at", updatable = false)

--- a/src/main/java/com/hugudungs/hugupjigup/data/entity/text_comment_type/CommentType.java
+++ b/src/main/java/com/hugudungs/hugupjigup/data/entity/text_comment_type/CommentType.java
@@ -1,0 +1,21 @@
+package com.hugudungs.hugupjigup.data.entity.text_comment_type;
+
+import com.hugudungs.hugupjigup.data.entity.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "comment_type")
+@Getter
+@Setter
+@NoArgsConstructor
+@AttributeOverrides({
+        @AttributeOverride(name = "id", column = @Column(name = "comment_type_id", nullable = false))
+})
+public class CommentType extends BaseEntity {
+
+    @Column(name = "comment_type", nullable = false)
+    private String type;  // 댓글 유형
+}

--- a/src/main/java/com/hugudungs/hugupjigup/data/entity/text_comment_type/TextType.java
+++ b/src/main/java/com/hugudungs/hugupjigup/data/entity/text_comment_type/TextType.java
@@ -1,0 +1,21 @@
+package com.hugudungs.hugupjigup.data.entity.text_comment_type;
+
+import com.hugudungs.hugupjigup.data.entity.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "text_type")
+@Getter
+@Setter
+@NoArgsConstructor
+@AttributeOverrides({
+        @AttributeOverride(name = "id", column = @Column(name = "text_type_id", nullable = false))
+})
+public class TextType extends BaseEntity {
+
+    @Column(name = "text_type", nullable = false)
+    private String type;  // 텍스트 유형
+}

--- a/src/main/java/com/hugudungs/hugupjigup/data/entity/user/User.java
+++ b/src/main/java/com/hugudungs/hugupjigup/data/entity/user/User.java
@@ -1,4 +1,43 @@
 package com.hugudungs.hugupjigup.data.entity.user;
 
-public class User {
+import com.hugudungs.hugupjigup.data.entity.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.util.Date;
+
+@Entity
+@Table(name = "user")
+@Getter
+@Setter
+@NoArgsConstructor
+@AttributeOverrides({
+        @AttributeOverride(name = "id", column = @Column(name = "text_type_id", nullable = false))
+})
+public class User extends BaseEntity {
+
+    @Column(name = "`Key`", nullable = false, length = 255)
+    private String key;  // 고유 키
+
+    @Column(name = "nickName", nullable = false)
+    private String nickName;  // 닉네임
+
+    @Column(name = "email", nullable = false)
+    private String email;  // 이메일
+
+    @Column(name = "password", nullable = false)
+    private String password;  // 비밀번호
+
+    @Column(name = "deleted_at")
+    @Temporal(TemporalType.DATE)
+    private Date deletedAt;  // 삭제 날짜 (NULL 허용)
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "login_type")
+    private LoginType loginType;  // 로그인 타입 (ENUM) (NULL 허용)
+
+    public enum LoginType {
+        GOOGLE, FACEBOOK, KAKAO, LOCAL
+    }
 }

--- a/src/main/java/com/hugudungs/hugupjigup/data/entity/user/User.java
+++ b/src/main/java/com/hugudungs/hugupjigup/data/entity/user/User.java
@@ -35,7 +35,7 @@ public class User extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "login_type")
-    private LoginType loginType;  // 로그인 타입 (ENUM) (NULL 허용)
+    private LoginType loginType;  // 로그인 타입 (ENUM) (이것도 NULL 허용)
 
     public enum LoginType {
         GOOGLE, FACEBOOK, KAKAO, LOCAL


### PR DESCRIPTION
1. 자유/멘토 게시판과 자유/멘토 게시판 댓글의 엔티티, 그리고 신청 대기열 엔티티를 구현했습니다.

2. 그리고 두 엔티티에서 게시글 타입, 댓글/후기 타입의 각 id를 참조하고 있기 때문에 이 또한 같이 구현했습니다.

3. 일대일, 일대다에 해당하는 어노테이션인 @OneToOne과 @ManyToOne의 사용 기준은 ERDCloud를 따랐습니다.

4. 또한 BaseEntity에 GenerationType.AUTO를 GenerationType.IDENTITY로 수정을 했는데 이는 이후에 AUTO_INCREMENT 설정을 자동으로 하도록 한 것입니다.