### PR TITLE
feature/entity/matching [유재우]: 매칭 게시판, 매칭 대기열 엔티티 작성

### DIFF
--- a/src/main/java/com/hugudungs/hugupjigup/data/entity/board/Matching.java
+++ b/src/main/java/com/hugudungs/hugupjigup/data/entity/board/Matching.java
@@ -1,0 +1,18 @@
+package com.hugudungs.hugupjigup.data.entity.board;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name="matching")
+@AttributeOverrides({
+        @AttributeOverride(name = "title", column = @Column(name = "matching_title")),
+        @AttributeOverride(name = "content", column = @Column(name = "matching_content"))
+})
+public class Matching extends BaseBoardEntity {
+    @Column(nullable = false)
+    private String tag; // 태그 (예: 작업, 기술)
+}

--- a/src/main/java/com/hugudungs/hugupjigup/data/entity/comment/ApplicationQueue.java
+++ b/src/main/java/com/hugudungs/hugupjigup/data/entity/comment/ApplicationQueue.java
@@ -1,5 +1,6 @@
 package com.hugudungs.hugupjigup.data.entity.comment;
 
+import com.hugudungs.hugupjigup.data.entity.common.BaseEntity;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Column;
@@ -8,10 +9,9 @@ import jakarta.persistence.Table;
 
 @Entity
 @Table(name="application_queue")
-@AttributeOverrides({
-        @AttributeOverride(name = "content", column = @Column(name = "application_queue_content"))
-})
-public class ApplicationQueue extends BaseComment {
+public class ApplicationQueue extends BaseEntity {
+    @Column(nullable = false)
+    private String content;
 
     @Column(nullable = false)
     private Enum status; // 대기열 상태를 뜻함 (Ex. 대기중, 승낙, 멘토링 완료)

--- a/src/main/java/com/hugudungs/hugupjigup/data/entity/comment/ApplicationQueue.java
+++ b/src/main/java/com/hugudungs/hugupjigup/data/entity/comment/ApplicationQueue.java
@@ -1,0 +1,18 @@
+package com.hugudungs.hugupjigup.data.entity.comment;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name="application_queue")
+@AttributeOverrides({
+        @AttributeOverride(name = "content", column = @Column(name = "application_queue_content"))
+})
+public class ApplicationQueue extends BaseComment {
+
+    @Column(nullable = false)
+    private Enum status; // 대기열 상태를 뜻함 (Ex. 대기중, 승낙, 멘토링 완료)
+}

--- a/src/main/java/com/hugudungs/hugupjigup/data/entity/comment/BaseComment.java
+++ b/src/main/java/com/hugudungs/hugupjigup/data/entity/comment/BaseComment.java
@@ -1,0 +1,12 @@
+package com.hugudungs.hugupjigup.data.entity.comment;
+
+import com.hugudungs.hugupjigup.data.entity.common.BaseEntity;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Data;
+
+@Data
+@MappedSuperclass
+public abstract class BaseComment extends BaseEntity {
+
+    private String content;
+}

--- a/src/main/java/com/hugudungs/hugupjigup/data/entity/comment/BaseCommentEntity.java
+++ b/src/main/java/com/hugudungs/hugupjigup/data/entity/comment/BaseCommentEntity.java
@@ -1,12 +1,13 @@
 package com.hugudungs.hugupjigup.data.entity.comment;
 
 import com.hugudungs.hugupjigup.data.entity.common.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Data;
 
 @Data
 @MappedSuperclass
-public abstract class BaseComment extends BaseEntity {
-
+public abstract class BaseCommentEntity extends BaseEntity {
+    @Column(nullable = false)
     private String content;
 }


### PR DESCRIPTION
- Matching: 매칭 게시판 엔티티
    - id: (PK) -> BaseEntity
    -  created_at: Null 허용 X -> BaseEntity
    - updated_at: Null 허용 X -> BaseEntity
    - matching_title: Null 허용 X -> BaseBoardEntity에서 컬럼 명만 변경
    - matching_content: Null 허용 X -> BaseBoardEntity에서 컬럼 명만 변경
    - tag: Null 허용 X -> (Ex. 작업, 기술)
- BaseComment: 댓글 공통 엔티티
    - id: (PK) -> BaseEntity
    -  created_at: Null 허용 X -> BaseEntity
    - updated_at: Null 허용 X -> BaseEntity
    - content: Null 허용 X
-  ApplicationQueue: 매칭 대기열 엔티티
    - id: (PK) -> BaseEntity
    -  created_at: Null 허용 X -> BaseEntity
    - updated_at: Null 허용 X -> BaseEntity 
    - application_queue_content: Null 허용 X -> BaseComment에서 컬럼 명만 변경
    - status: Null 허용 X -> 대기열 상태를 뜻함 (Ex. 대기중, 승낙, 멘토링 완료)